### PR TITLE
Fix Google Analytics

### DIFF
--- a/config/production/hugo.toml
+++ b/config/production/hugo.toml
@@ -1,3 +1,3 @@
 [services]
   [services.googleAnalytics]
-    googleAnalytics = "G-BLX24KP7CS"
+    ID = "G-BLX24KP7CS"


### PR DESCRIPTION
With the previous format, the script for Google Analytics is not generated in production as expected. Changing the key `googleAnalytics` to `ID` fixes this.